### PR TITLE
Add next sCMS workshop and improve main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Xerrades realitzades i planificació de les properes
 - [18/10/2017 - PyGRN#3](xerrades/2017/20171018) Python Data Science
 - [15/11/2017 - PyGRN#4](xerrades/2017/20171115) Django APP&API + React client
 - [17/01/2018 - PyGRN#5](xerrades/2018/20180117) Elastic Search
+- [21/02/2018 - PyGRN#6](xerrades/2018/20180221) Taller sCMS
 
 
 -----------------

--- a/README.md
+++ b/README.md
@@ -6,22 +6,23 @@ Aquí trobareu tot allò referent a *Python Girona*, entre altres:
 - localitzacions
 - discussions varies
 
+[Web](http://pythongirona.cat) | [Grup de Telegram](https://t.me/pygrn) | [Meetup](https://www.meetup.com/PythonGirona)
 
 -----------------
 
 
 ## Xerrades de PyGRN
 
-Propera trobada **13/09/2017**!
+Propera trobada **21/02/2018**!
 
 Xerrades realitzades i planificació de les properes
 
-- [12/07/2017 - PyGRN#1](xerrades/2017/20170712) Scrapy + Pandas
-- [13/09/2017 - PyGRN#2](xerrades/2017/20170913) No tot és programar
-- [18/10/2017 - PyGRN#3](xerrades/2017/20171018) Python Data Science
-- [15/11/2017 - PyGRN#4](xerrades/2017/20171115) Django APP&API + React client
-- [17/01/2018 - PyGRN#5](xerrades/2018/20180117) Elastic Search
-- [21/02/2018 - PyGRN#6](xerrades/2018/20180221) Taller sCMS
+- [12/07/2017 - PyGRN#1](xerrades/2017/20170712) **Scrapy + Pandas**
+- [13/09/2017 - PyGRN#2](xerrades/2017/20170913) **No tot és programar**
+- [18/10/2017 - PyGRN#3](xerrades/2017/20171018) **Python Data Science**
+- [15/11/2017 - PyGRN#4](xerrades/2017/20171115) **Django APP&API + React client**
+- [17/01/2018 - PyGRN#5](xerrades/2018/20180117) **Elastic Search**
+- [21/02/2018 - PyGRN#6](xerrades/2018/20180221) **Taller sCMS #WIP**
 
 
 -----------------


### PR DESCRIPTION
sCMS workshop has been integrated to the sessions list

Social links are integrated at main README
- Telegram group
- Website
- Meetup

Next date has been fixed... not updated since 13/09/2017! 