### PR TITLE
Add Scientific Python talk and resources

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "xerrades/2018/20181018/docker101"]
 	path = xerrades/2018/20181018/docker101
 	url = git@github.com:pygrn/docker101.git
+[submodule "xerrades/2019/20190207/scipy"]
+	path = xerrades/2019/20190207/scipy
+	url = https://github.com/efarres/pygrn-scipy.git

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python Girona
 
-Aquí trobareu tot allò referent a *Python Girona*, entre altres: 
+Aquí trobareu tot allò referent a *Python Girona*, entre altres:
 - xerrades
 - proposta de xerrades i temes
 - localitzacions
@@ -28,6 +28,7 @@ Xerrades realitzades i planificació de les properes
 - [18/10/2018 - PyGRN#9](xerrades/2018/20181018) **Docker 101**
 - [15/11/2018 - PyGRN#10](xerrades/2018/20181115) **Pentesting Python**
 - [13/12/2018 - PyGRN#11](xerrades/2018/20181213) **Taller introducció VueJS**
+- [07/02/2019 - PyGRN#12](xerrades/2019/20190207) **Scientific Python**
 
 
 -----------------
@@ -35,7 +36,7 @@ Xerrades realitzades i planificació de les properes
 
 ## Idees per a les xerrades
 
-Si tens ganes de preparar una sessió específica tractant un tema en concret aquest és el teu lloc! 
+Si tens ganes de preparar una sessió específica tractant un tema en concret aquest és el teu lloc!
 
 **No tinguis por** i [obre una issue](https://github.com/pygrn/xerrades/issues/new)!
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Aquí trobareu tot allò referent a *Python Girona*, entre altres:
 
 ## Xerrades de PyGRN
 
-Propera trobada **21/02/2018**!
+Propera trobada **07/03/2019** :: Taller Docker!!!
 
 Xerrades realitzades i planificació de les properes
 

--- a/xerrades/2019/20190207/README.md
+++ b/xerrades/2019/20190207/README.md
@@ -5,7 +5,7 @@ Ens veurem al [Parc Tecnològic](http://www.openstreetmap.org/way/63929565), a l
 ### Agenda
 
 - `19:00 - 19:10`  Benvinguda
-- `19:10 - 20:15`  [Scientific Python](https://github.com/pygrn/xerrades/issues/48) per [Esteve Farrés](https://github.com/efarres) [[Slides](https://talks.godoc.org/github.com/efarres/pygrn-scipy/slides_pygrn_scipy.slide)] [[Repo]()https://github.com/efarres/pygrn-scipy]
+- `19:10 - 20:15`  [Scientific Python](https://github.com/pygrn/xerrades/issues/48) per [Esteve Farrés](https://github.com/efarres) [[Slides](https://talks.godoc.org/github.com/efarres/pygrn-scipy/slides_pygrn_scipy.slide)] [[Repo](https://github.com/efarres/pygrn-scipy)]
 - `20:15 - 22:00`  Debat i pizzes
 
 [Meetup](https://www.meetup.com/PythonGirona/events/255369313/)

--- a/xerrades/2019/20190207/README.md
+++ b/xerrades/2019/20190207/README.md
@@ -8,4 +8,4 @@ Ens veurem al [Parc Tecnològic](http://www.openstreetmap.org/way/63929565), a l
 - `19:10 - 20:15`  [Scientific Python](https://github.com/pygrn/xerrades/issues/48) per [Esteve Farrés](https://github.com/efarres) [[Slides](https://talks.godoc.org/github.com/efarres/pygrn-scipy/slides_pygrn_scipy.slide)] [[Repo](https://github.com/efarres/pygrn-scipy)]
 - `20:15 - 22:00`  Debat i pizzes
 
-[Meetup](https://www.meetup.com/PythonGirona/events/255369313/)
+[Meetup](https://www.meetup.com/PythonGirona/events/258591484/)

--- a/xerrades/2019/20190207/README.md
+++ b/xerrades/2019/20190207/README.md
@@ -1,0 +1,11 @@
+# 07/02/2019 :: #12 Scientific Python
+
+Ens veurem al [Parc Tecnològic](http://www.openstreetmap.org/way/63929565), a les 19:00.
+
+### Agenda
+
+- `19:00 - 19:10`  Benvinguda
+- `19:10 - 20:15`  [Scientific Python](https://github.com/pygrn/xerrades/issues/48) per [Esteve Farrés](https://github.com/efarres) [[Slides](https://talks.godoc.org/github.com/efarres/pygrn-scipy/slides_pygrn_scipy.slide)] [[Repo]()https://github.com/efarres/pygrn-scipy]
+- `20:15 - 22:00`  Debat i pizzes
+
+[Meetup](https://www.meetup.com/PythonGirona/events/255369313/)


### PR DESCRIPTION
It provides the **Scientific Python** talk and their related resources

It also deploys the related repo as a submodule inside talk directory